### PR TITLE
fixed `isdicom`

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -136,8 +136,12 @@ function find_dicom_files(dir)
 end
 
 function isdicom(file)
-    bytes = read(file, 132)[end-3:end]
-    String(bytes) == "DICM"
+    try
+        bytes = read(file, 132)[end-3:end]
+        String(bytes) == "DICM"
+    catch
+        not_dicom == true
+    end
 end
 
 function dcmdir_parse(dir; kwargs...)


### PR DESCRIPTION
added `try` and `catch` statements which should get around the fact that not all directories are pure DICOM files