### PR TITLE
Create an invalid file during tests to check isdicom()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DICOM"
 uuid = "a26e6606-dd52-5f6a-a97f-4f611373d757"
-version = "0.10.0"
+version = "0.10.1"
 
 [compat]
 julia = "0.7, 1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,19 +226,21 @@ end
 @testset "Parse entire folder" begin
     # Following files have missing preamble and won't be parsed
     # ["OT_Implicit_Little_Headless.dcm", "CT_Implicit_Little_Headless_Retired.dcm"]
-    # and brain.bpm is not a DICOM file
+    # along with an invalid notdicom.dcm file which we will first create 
+    notdicomfile = joinpath(data_folder, "notdicom.dcm")
+    open(notdicomfile, "w") do io
+      print(io, "Not valid dicom file")
+    end
+    
+    # First, test the isdicom() function
+    fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
+    @test DICOM.isdicom(fileDX) == true
+    @test DICOM.isdicom(notdicomfile) == false
+
+    # Second, test if all valid dicom file can be parsed
     dcms = dcmdir_parse(data_folder)
     @test issorted([dcm[tag"Instance Number"] for dcm in dcms])
     @test length(dcms) == length(readdir(data_folder)) - 3 # -3 because of note above
-end
-
-@testset "isdicom" begin
-    answer = DICOM.isdicom("test/testdata/brain.bmp")
-    @test answer === false
-
-    fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
-    answer2 = DICOM.isdicom(fileDX)
-    @test answer2 == true
 end
 
 @testset "Test tag macro" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,7 +229,7 @@ end
     # along with an invalid notdicom.dcm file which we will first create 
     notdicomfile = joinpath(data_folder, "notdicom.dcm")
     open(notdicomfile, "w") do io
-      print(io, "Not valid dicom file")
+      print(io, "!")
     end
     
     # First, test the isdicom() function


### PR DESCRIPTION
This PR creates a fake dicom file during the tests, rather than assuming that a `brain.bmp` file exists in the test data folder.
The tests for parsing a folder and for testing `isdicom()` are also merged for simplicity. 
